### PR TITLE
Feature/transform refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,3 +89,35 @@ If your client supports variable replacement, you can simply pass them into your
 # {deviceFormfactor} is replaced in client...
 assertions.assert_await_transform_exists(cli, "Kiosk-{deviceFormFactor}(Clone"), timeout_seconds=10)
 ```
+
+### Transform References
+In cases where two or more sibling transforms have the same name, the transform path is ambiguous. This makes it difficult to specify the correct transform, as the example below illustrates:
+
+```python
+# Suppose both buttons have the same transform path: "Path/To/Menu/Button"
+
+# Fetch button0 position using transform path
+button0_position = commands.fetch_transform_screen_position(cli, "Path/To/Menu/Button")
+
+# Can't fetch button1 position using transform path because transform path is ambiguous
+button1_position = ???
+```
+
+To resolve the ambiguity, you can use a transform reference, which supplements the transform path with sibling indices to yield a unique path for each transform. Use the `fetch_transform` command to obtain a transform reference:
+
+```python
+# Suppose both buttons have the same transform path: "Path/To/Menu/Button"
+
+# Obtain a transform reference
+menu = commands.fetch_transform(cli, "Path/To/Menu")
+
+# Fetch button0 position using transform reference
+button0_position = commands.fetch_transform_screen_position(cli, menu.children[0])
+
+# Fetch button1 position using transform reference
+button1_position = commands.fetch_transform_screen_position(cli, menu.children[1])
+```
+
+<Warning>
+*Transform references are only valid as long as the transform hierarchy doesn't change. If the hierarchy changes (e.g. a transform is created or deleted, or the sibling order changes), you must call `fetch_transform` again to obtain updated transform references.*
+</Warning>

--- a/README.md
+++ b/README.md
@@ -118,6 +118,6 @@ button0_position = commands.fetch_transform_screen_position(cli, menu.children[0
 button1_position = commands.fetch_transform_screen_position(cli, menu.children[1])
 ```
 
-<Warning>
-*Transform references are only valid as long as the transform hierarchy doesn't change. If the hierarchy changes (e.g. a transform is created or deleted, or the sibling order changes), you must call `fetch_transform` again to obtain updated transform references.*
-</Warning>
+<aside class="warning">
+Transform references are only valid as long as the transform hierarchy doesn't change. If the hierarchy changes (e.g. a transform is created or deleted, or the sibling order changes), you must call `fetch_transform` again to obtain updated transform references.
+</aside>

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ In cases where two or more sibling transforms have the same name, the transform 
 button0_position = commands.fetch_transform_screen_position(cli, "Path/To/Menu/Button")
 
 # Can't fetch button1 position using transform path because transform path is ambiguous
-button1_position = ???
+button1_position = # ???
 ```
 
 To resolve the ambiguity, you can use a transform reference, which supplements the transform path with sibling indices to yield a unique path for each transform. Use the `fetch_transform` command to obtain a transform reference:
@@ -118,6 +118,4 @@ button0_position = commands.fetch_transform_screen_position(cli, menu.children[0
 button1_position = commands.fetch_transform_screen_position(cli, menu.children[1])
 ```
 
-<aside class="warning">
-Transform references are only valid as long as the transform hierarchy doesn't change. If the hierarchy changes (e.g. a transform is created or deleted, or the sibling order changes), you must call `fetch_transform` again to obtain updated transform references.
-</aside>
+> *Warning:* Transform references are only valid as long as the transform hierarchy doesn't change. If the hierarchy changes (e.g. a transform is created or deleted, or the sibling order changes), you must call `fetch_transform` again to obtain updated transform references.

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ assertions.assert_await_transform_exists(cli, "Kiosk-{deviceFormFactor}(Clone"),
 ```
 
 ### Transform References
-In cases where two or more sibling transforms have the same name, the transform path is ambiguous. This makes it difficult to specify the correct transform, as the example below illustrates:
+If two or more sibling transforms have the same name, the transform path is ambiguous. This makes it difficult to specify the correct transform, as the example below illustrates:
 
 ```python
 # Suppose both buttons have the same transform path: "Path/To/Menu/Button"

--- a/coeus_unity/assertions.py
+++ b/coeus_unity/assertions.py
@@ -6,14 +6,14 @@ DEFAULT_RENDERER_VISIBLE = True
 DEFAULT_SCENE_LOADED = True
 
 
-def assert_transform_exists(cli, transform_path):
+def assert_transform_exists(cli, transform_ref):
     """
     Asserts that the transform exists.
     :param cli:
-    :param transform_path:
+    :param transform_ref:
     :return:
     """
-    result = commands.query_transform_exists(cli, transform_path)
+    result = commands.query_transform_exists(cli, transform_ref)
     assert result is True
     return result
 
@@ -30,62 +30,62 @@ def assert_scene_loaded(cli, scene_name):
     return result
 
 
-def assert_await_transform_exists(cli, transform_path, does_exist=DEFAULT_TRANSFORM_EXISTS, timeout_seconds=DEFAULT_TIMEOUT_SECONDS):
+def assert_await_transform_exists(cli, transform_ref, does_exist=DEFAULT_TRANSFORM_EXISTS, timeout_seconds=DEFAULT_TIMEOUT_SECONDS):
     """
     Asserts that we successfully awaited for the transform to exist based on does_exist. If the timeout passes
     or the expression is_registered != actual state, then it will fail.
     :param cli:
-    :param transform_path:
+    :param transform_ref:
     :param does_exist: (True | False) the state change we are waiting for.
     :param timeout_seconds: The amount of time to wait for a change before fail.
     :return:
     """
-    result = commands.await_transform_exists(cli, transform_path, does_exist, timeout_seconds)
+    result = commands.await_transform_exists(cli, transform_ref, does_exist, timeout_seconds)
     assert result is True
     return result
 
 
-def assert_await_any_transforms_exist(cli, transform_paths, does_exist=DEFAULT_TRANSFORM_EXISTS, timeout_seconds=DEFAULT_TIMEOUT_SECONDS):
+def assert_await_any_transforms_exist(cli, transform_refs, does_exist=DEFAULT_TRANSFORM_EXISTS, timeout_seconds=DEFAULT_TIMEOUT_SECONDS):
     """
     Asserts that we successfully awaited for any transforms to exist based on does_exist. If the timeout passes
     or the expression is_registered != actual state, then it will fail.
     :param cli:
-    :param transform_paths:
+    :param transform_refs:
     :param does_exist: (True | False) the state change we are waiting for.
     :param timeout_seconds: The amount of time to wait for a change before fail.
     :return:
     """
-    result = commands.await_any_transforms_exist(cli, transform_paths, does_exist, timeout_seconds)
+    result = commands.await_any_transforms_exist(cli, transform_refs, does_exist, timeout_seconds)
     assert result is True
     return result
 
 
-def assert_await_all_transforms_exist(cli, transform_paths, does_exist=DEFAULT_TRANSFORM_EXISTS, timeout_seconds=DEFAULT_TIMEOUT_SECONDS):
+def assert_await_all_transforms_exist(cli, transform_refs, does_exist=DEFAULT_TRANSFORM_EXISTS, timeout_seconds=DEFAULT_TIMEOUT_SECONDS):
     """
     Asserts that we successfully awaited for all transforms to exist based on does_exist. If the timeout passes
     or the expression is_registered != actual state, then it will fail.
     :param cli:
-    :param transform_paths:
+    :param transform_refs:
     :param does_exist: (True | False) the state change we are waiting for.
     :param timeout_seconds: The amount of time to wait for a change before fail.
     :return:
     """
-    result = commands.await_all_transforms_exist(cli, transform_paths, does_exist, timeout_seconds)
+    result = commands.await_all_transforms_exist(cli, transform_refs, does_exist, timeout_seconds)
     assert result is True
     return result
 
 
-def assert_await_renderer_visible(cli, transform_path, is_visible=DEFAULT_RENDERER_VISIBLE, timeout_seconds=DEFAULT_TIMEOUT_SECONDS):
+def assert_await_renderer_visible(cli, transform_ref, is_visible=DEFAULT_RENDERER_VISIBLE, timeout_seconds=DEFAULT_TIMEOUT_SECONDS):
     """
     Asserts that we successfully awaited for the renderer to be visible based on is_visible. If the timeout passes
     or the expression is_registered != actual state, then it will fail.
     :param cli:
-    :param transform_path:
+    :param transform_ref:
     :param is_visible: (True | False) the state change we are waiting for.
     :param timeout_seconds: The amount of time to wait for a change before fail.
     :return:
     """
-    result = commands.await_renderer_visible(cli, transform_path, is_visible, timeout_seconds)
+    result = commands.await_renderer_visible(cli, transform_ref, is_visible, timeout_seconds)
     assert result is True
     return result
 
@@ -105,33 +105,33 @@ def assert_await_scene_loaded(cli, scene_name, is_loaded=DEFAULT_SCENE_LOADED, t
     return result
 
 
-def assert_component_value_equals(cli, transform_path, component_type, name, value):
+def assert_component_value_equals(cli, transform_ref, component_type, name, value):
     """
     Asserts that component field or property equals to the provided value
     :param cli:
-    :param transform_path:
+    :param transform_ref:
     :param component_type: The C# type name of the component GetComponent(type)
     :param name: The field or property name.
     :param value: The value to check for equality (String | Number | Boolean)
     :return:
     """
 
-    result = commands.fetch_component_value(cli, transform_path, component_type, name)
+    result = commands.fetch_component_value(cli, transform_ref, component_type, name)
     assert result == value
     return result
 
 
-def assert_await_component_value_equals(cli, transform_path, component_type, name, value, timeout_seconds=DEFAULT_TIMEOUT_SECONDS):
+def assert_await_component_value_equals(cli, transform_ref, component_type, name, value, timeout_seconds=DEFAULT_TIMEOUT_SECONDS):
     """
     Asserts that we successfully awaited for the component field or property to become provided value.
     :param cli:
-    :param transform_path: The path of the transform where the component resides
+    :param transform_ref: Reference to the transform where the component resides
     :param component_type: The C# type name of the component GetComponent(type)
     :param name: The field or property name.
     :param value: The value to check for equality (String | Number | Boolean)
     :return:
     """
 
-    result = commands.await_component_value_equals(cli, transform_path, component_type, name, value, timeout_seconds)
+    result = commands.await_component_value_equals(cli, transform_ref, component_type, name, value, timeout_seconds)
     assert result is True
     return result

--- a/coeus_unity/commands.py
+++ b/coeus_unity/commands.py
@@ -1,22 +1,26 @@
 from coeus_test.commands import verify_response
 import coeus_test.message as message
+from coeus_unity.transform import TransformRef
 
 DEFAULT_TIMEOUT_SECONDS = 60
+DEFAULT_RECURSIVE = True
 DEFAULT_TRANSFORM_EXISTS = True
 DEFAULT_RENDERER_VISIBLE = True
 DEFAULT_SCENE_LOADED = True
 
 
-def query_transform_exists(cli, transform_path):
+def query_transform_exists(cli, transform_ref):
     """
     Requests status on whether a transform exists or not.
     :param cli:
-    :param transform_path:
+    :param transform_ref:
     :return: bool
     """
+    # Ensure backwards compatibility with previous versions of this command that took a transform_path string.
+    transform_ref = _convert_to_transform_ref(transform_ref)
 
     message_payload = {
-        "transform_path": transform_path
+        "transform_ref": TransformRef.to_payload(transform_ref)
     }
     msg = message.Message("query.unity.transform.exists", message_payload)
     cli.send_message(msg)
@@ -26,17 +30,20 @@ def query_transform_exists(cli, transform_path):
     return bool(response['payload']['result'])
 
 
-def await_transform_exists(cli, transform_path, does_exist=DEFAULT_TRANSFORM_EXISTS, timeout_seconds=DEFAULT_TIMEOUT_SECONDS):
+def await_transform_exists(cli, transform_ref, does_exist=DEFAULT_TRANSFORM_EXISTS, timeout_seconds=DEFAULT_TIMEOUT_SECONDS):
     """
     Waits for a single transform to exist based on does_exist.
     :param cli:
-    :param transform_path:
+    :param transform_ref:
     :param does_exist: Whether or not to await for exist state (True | False)
     :param timeout_seconds: How long until this returns with failure
     :return: bool
     """
+    # Ensure backwards compatibility with previous versions of this command that took a transform_path string.
+    transform_ref = _convert_to_transform_ref(transform_ref)
+
     message_payload = {
-        "transform_paths": [transform_path],
+        "transform_refs": TransformRef.list_to_payload([transform_ref]),
         "do_exist": does_exist,
         "match_mode": "All",
         "timeout": timeout_seconds
@@ -49,17 +56,20 @@ def await_transform_exists(cli, transform_path, does_exist=DEFAULT_TRANSFORM_EXI
     return bool(response['payload']['success'])
 
 
-def await_any_transforms_exist(cli, transform_paths, does_exist=DEFAULT_TRANSFORM_EXISTS, timeout_seconds=DEFAULT_TIMEOUT_SECONDS):
+def await_any_transforms_exist(cli, transform_refs, does_exist=DEFAULT_TRANSFORM_EXISTS, timeout_seconds=DEFAULT_TIMEOUT_SECONDS):
     """
     Waits for a transform to exist based on does_exist.
     :param cli:
-    :param transform_paths: An array of transform paths [...]
+    :param transform_refs: An array of transform paths [...]
     :param does_exist: Whether or not to await for exist state (True | False)
     :param timeout_seconds: How long until this returns with failure
     :return: bool
     """
+    # Ensure backwards compatibility with previous versions of this command that took a transform_paths string array.
+    transform_refs = _convert_to_transform_refs(transform_refs)
+    
     message_payload = {
-        "transform_paths": transform_paths,
+        "transform_refs": TransformRef.list_to_payload(transform_refs),
         "do_exist": does_exist,
         "match_mode": "Any",
         "timeout": timeout_seconds
@@ -72,17 +82,20 @@ def await_any_transforms_exist(cli, transform_paths, does_exist=DEFAULT_TRANSFOR
     return bool(response['payload']['success'])
 
 
-def await_all_transforms_exist(cli, transform_paths, does_exist=DEFAULT_TRANSFORM_EXISTS, timeout_seconds=DEFAULT_TIMEOUT_SECONDS):
+def await_all_transforms_exist(cli, transform_refs, does_exist=DEFAULT_TRANSFORM_EXISTS, timeout_seconds=DEFAULT_TIMEOUT_SECONDS):
     """
-    Waits for all transforms specified in transform_paths to exist or not based on does_exist.
+    Waits for all transforms specified in transform_refs to exist or not based on does_exist.
     :param cli:
-    :param transform_paths: An array of transform paths [...]
+    :param transform_refs: An array of transform paths [...]
     :param does_exist: Whether or not to await for exist state (True | False)
     :param timeout_seconds: How long until this returns with failure
     :return: bool
     """
+    # Ensure backwards compatibility with previous versions of this command that took a transform_paths string array.
+    transform_refs = _convert_to_transform_refs(transform_refs)
+    
     message_payload = {
-        "transform_paths": transform_paths,
+        "transform_refs": TransformRef.list_to_payload(transform_refs),
         "do_exist": does_exist,
         "match_mode": "All",
         "timeout": timeout_seconds
@@ -95,17 +108,70 @@ def await_all_transforms_exist(cli, transform_paths, does_exist=DEFAULT_TRANSFOR
     return bool(response['payload']['success'])
 
 
-def fetch_transform_screen_position(cli, transform_path):
+def fetch_transform(cli, transform_ref, recursive=DEFAULT_RECURSIVE):
+    """
+    Wrapper around ``fetch_transform_children`` that returns the original transform reference instead of its children.
+
+    :param cli:
+    :param transform_ref: Specifies the transform to request children for.
+    :param recursive: If True, fetch children recursively; otherwise, fetch immediate children only.
+    :return: The original transform reference, with its ``children`` property set as described in the documentation for
+    the ``fetch_transform_children`` command.
+    """
+    # Ensure backwards compatibility with previous versions of this command that took a transform_path string.
+    transform_ref = _convert_to_transform_ref(transform_ref)
+
+    fetch_transform_children(cli, transform_ref, recursive)
+
+    return transform_ref
+
+
+def fetch_transform_children(cli, transform_ref, recursive=DEFAULT_RECURSIVE):
+    """
+    Requests children of the specified transform. Children may optionally be fetched recursively.
+
+    Children are returned as an array of TransformRef instances. Each instance has a ``children`` property, which is
+    interpreted as follows:
+        * If children = None, the property wasn't fetched (recursive = False).
+        * If children = [], the property was fetched (recursive = True), but the TransformRef doesn't have children.
+    :param cli:
+    :param transform_ref: Specifies the transform to request children for.
+    :param recursive: If True, fetch children recursively; otherwise, fetch immediate children only.
+    :return: Array of TransformRefs representing the immediate children of the specified transform. If children are
+    fetched recursively (recursive = True), then grandchildren, etc. can be accessed via the ``children`` property of
+    the returned TransformRefs.
+    """
+    # Ensure backwards compatibility with previous versions of this command that took a transform_path string.
+    transform_ref = _convert_to_transform_ref(transform_ref)
+    
+    message_payload = {
+        "transform_ref": TransformRef.to_payload(transform_ref),
+        "recursive": recursive
+    }
+
+    msg = message.Message("fetch.unity.transform.children", message_payload)
+    cli.send_message(msg)
+
+    response = cli.read_message()
+    verify_response(response)
+
+    children = TransformRef.list_from_payload(response['payload']['children'], transform_ref)
+    return children
+
+
+def fetch_transform_screen_position(cli, transform_ref):
     """
     Requests screen position of a transform at path. WorldToScreenPoint is used for 3D, otherwise
     a screen-scaled center of RectTransform is used.
     :param cli:
-    :param transform_path:
+    :param transform_ref:
     :return: [x,y]
     """
-
+    # Ensure backwards compatibility with previous versions of this command that took a transform_path string.
+    transform_ref = _convert_to_transform_ref(transform_ref)
+    
     message_payload = {
-        "transform_path": transform_path
+        "transform_ref": TransformRef.to_payload(transform_ref)
     }
     msg = message.Message("fetch.unity.transform.screenPosition", message_payload)
     cli.send_message(msg)
@@ -118,17 +184,19 @@ def fetch_transform_screen_position(cli, transform_path):
     ]
 
 
-def fetch_transform_normalized_screen_position(cli, transform_path):
+def fetch_transform_normalized_screen_position(cli, transform_ref):
     """
     Requests screen position of a transform at path. WorldToScreenPoint is used for 3D, otherwise
     a screen-scaled center of RectTransform is used.
     :param cli:
-    :param transform_path:
+    :param transform_ref:
     :return: [x,y]
     """
-
+    # Ensure backwards compatibility with previous versions of this command that took a transform_path string.
+    transform_ref = _convert_to_transform_ref(transform_ref)
+    
     message_payload = {
-        "transform_path": transform_path
+        "transform_ref": TransformRef.to_payload(transform_ref)
     }
     msg = message.Message("fetch.unity.transform.screenPosition", message_payload)
     cli.send_message(msg)
@@ -141,16 +209,18 @@ def fetch_transform_normalized_screen_position(cli, transform_path):
     ]
 
 
-def query_renderer_visible(cli, transform_path):
+def query_renderer_visible(cli, transform_ref):
     """
-    Requests status on whether a renderer at transform_path is visible.
+    Requests status on whether a renderer at transform_ref is visible.
     :param cli:
-    :param transform_path:
+    :param transform_ref:
     :return: bool
     """
-
+    # Ensure backwards compatibility with previous versions of this command that took a transform_path string.
+    transform_ref = _convert_to_transform_ref(transform_ref)
+    
     message_payload = {
-        "transform_path": transform_path
+        "transform_ref": TransformRef.to_payload(transform_ref)
     }
     msg = message.Message("query.unity.renderer.visible", message_payload)
     cli.send_message(msg)
@@ -160,17 +230,20 @@ def query_renderer_visible(cli, transform_path):
     return bool(response['payload']['result'])
 
 
-def await_renderer_visible(cli, transform_path, is_visible=DEFAULT_RENDERER_VISIBLE, timeout_seconds=DEFAULT_TIMEOUT_SECONDS):
+def await_renderer_visible(cli, transform_ref, is_visible=DEFAULT_RENDERER_VISIBLE, timeout_seconds=DEFAULT_TIMEOUT_SECONDS):
     """
     Waits for a transform renderer to become visible based on is_visible.
     :param cli:
-    :param transform_path:
+    :param transform_ref:
     :param is_visible: Whether or not to await for visible state (True | False)
     :param timeout_seconds: How long until this returns with failure
     :return: bool
     """
+    # Ensure backwards compatibility with previous versions of this command that took a transform_path string.
+    transform_ref = _convert_to_transform_ref(transform_ref)
+    
     message_payload = {
-        "transform_path": transform_path,
+        "transform_ref": TransformRef.to_payload(transform_ref),
         "is_visible": is_visible,
         "timeout": timeout_seconds
     }
@@ -223,18 +296,20 @@ def await_scene_loaded(cli, scene_name, is_loaded=DEFAULT_SCENE_LOADED, timeout_
     return bool(response['payload']['success'])
 
 
-def fetch_component_value(cli, transform_path, component_type, name):
+def fetch_component_value(cli, transform_ref, component_type, name):
     """
     Requests value from a component field or property
     :param cli:
-    :param transform_path: The path of the transform where the component resides
+    :param transform_ref: The path of the transform where the component resides
     :param component_type: The C# type name of the component GetComponent(type)
     :param name: The field or property name.
     :return: Component value
     """
-
+    # Ensure backwards compatibility with previous versions of this command that took a transform_path string.
+    transform_ref = _convert_to_transform_ref(transform_ref)
+    
     message_payload = {
-        "transform_path": transform_path,
+        "transform_ref": TransformRef.to_payload(transform_ref),
         "component_type": component_type,
         "name": name
     }
@@ -246,19 +321,21 @@ def fetch_component_value(cli, transform_path, component_type, name):
     return response['payload']['result']
 
 
-def assign_component_value(cli, transform_path, component_type, name, value):
+def assign_component_value(cli, transform_ref, component_type, name, value):
     """
     Assigns a value to a component
     :param cli:
-    :param transform_path: The path of the transform where the component resides
+    :param transform_ref: The path of the transform where the component resides
     :param component_type: The C# type name of the component GetComponent(type)
     :param name: The field or property name.
     :param value: The value to assign (String | Number | Boolean)
     :return: bool
     """
-
+    # Ensure backwards compatibility with previous versions of this command that took a transform_path string.
+    transform_ref = _convert_to_transform_ref(transform_ref)
+    
     message_payload = {
-        "transform_path": transform_path,
+        "transform_ref": TransformRef.to_payload(transform_ref),
         "component_type": component_type,
         "name": name,
         "value": value
@@ -270,19 +347,22 @@ def assign_component_value(cli, transform_path, component_type, name, value):
     verify_response(response)
 
 
-def await_component_value_equals(cli, transform_path, component_type, name, value, timeout_seconds=DEFAULT_TIMEOUT_SECONDS):
+def await_component_value_equals(cli, transform_ref, component_type, name, value, timeout_seconds=DEFAULT_TIMEOUT_SECONDS):
     """
     Waits for component field or property to become provided value
     :param cli:
-    :param transform_path: The path of the transform where the component resides
+    :param transform_ref: The path of the transform where the component resides
     :param component_type: The C# type name of the component GetComponent(type)
     :param name: The field or property name.
     :param value: The value to check for equality (String | Number | Boolean)
     :param timeout_seconds: How long until this returns with failure
     :return bool(response['payload']['success'])
     """
+    # Ensure backwards compatibility with previous versions of this command that took a transform_path string.
+    transform_ref = _convert_to_transform_ref(transform_ref)
+    
     message_payload = {
-        "transform_path": transform_path,
+        "transform_ref": TransformRef.to_payload(transform_ref),
         "component_type": component_type,
         "name": name,
         "value": value,
@@ -294,3 +374,34 @@ def await_component_value_equals(cli, transform_path, component_type, name, valu
     response = cli.read_message()
     verify_response(response)
     return bool(response['payload']['success'])
+
+
+def _convert_to_transform_ref(transform_ref):
+    """
+    Converts the input to a TransformRef. If the input is already a TransformRef, no conversion is performed.
+
+    Conversion is performed to ensure backwards compatibility with commands that previously took a transform_path,
+    which now take a transform_ref to distinguish between multiple transforms with the same path.
+    :param transform_ref: an instance of TransformRef, or a string representing a transform path.
+    :return: If the input is already a TransformRef, no conversion is performed; otherwise, returns a new instance of
+    TransformRef containing the specified transform path.
+    """
+    if not isinstance(transform_ref, TransformRef):
+        transform_ref = TransformRef(transform_ref)
+    return transform_ref
+
+
+def _convert_to_transform_refs(transform_refs):
+    """
+    Converts the input to an array of TransformRef. If the input is already an array of TransformRef, no conversion is
+    performed.
+
+    Conversion is performed to ensure backwards compatibility with commands that previously took a transform_path,
+    which now take a transform_ref to distinguish between multiple transforms with the same path.
+    :param transform_refs: an array of TransformRef, or an array of strings representing transform paths.
+    :return: If the input is already an array of TransformRef, no conversion is performed; otherwise, returns an array
+    of TransformRefs containing the specified transform paths.
+    """
+    for i in range(len(transform_refs)):
+        transform_refs[i] = _convert_to_transform_ref(transform_refs[i])
+    return transform_refs

--- a/coeus_unity/transform.py
+++ b/coeus_unity/transform.py
@@ -1,67 +1,297 @@
 class TransformRef:
-    id = None
-    transform_path = None
-    children = []
-    parent = None
+    """
+    Reference to a Unity transform with a given transform path, along with an optional sibling index that can be used
+    to distinguish between sibling transforms with the same path. Also contains optional references to parent and child
+    transforms to allow navigation of the transform hierarchy.
 
-    def __init__(self, transform_path):
+    If the ``children`` attribute is None, it simply means that the attribute is uninitialized. The referenced
+    transform may or may not actually have children.
+
+    If the ``children`` attribute is an empty list, it means the referenced transform has no children.
+    """
+
+    def __init__(self, transform_path, sibling_index=-1, parent=None):
+        """
+        Initializes this TransformRef instance.
+
+        :param transform_path: Parent-relative transform path, or the absolute path if ``parent`` is None.
+        :param sibling_index: Optional sibling index, used to distinguish between sibling transforms with the same path.
+        :param parent: Optional parent transform reference.
+        """
+        # Make sure the transform path is valid.
+        if not isinstance(transform_path, str):
+            raise ValueError("transform_path must be of type str")
+
+        # Make sure the parent transform reference is valid.
+        if (parent is not None) and not isinstance(parent, TransformRef):
+            raise ValueError("parent must be None or of type TransformRef")
+
+        # Define instance attributes.
         self.id = id
         self.transform_path = transform_path
+        self.sibling_index = sibling_index
+        self.children = None
+        self.parent = None
 
-    def add_child_ref(self, transform_ref):
-        """
-        Adds the TransformRef if it is not already added.
-        :param transform_ref:
-        :return:
-        """
-        if not isinstance(transform_ref, TransformRef):
-            raise ValueError("transform_ref must be of type TransformRef")
+        self.set_parent(parent)
 
-        for child in self.children:
-            if child is transform_ref:
-                return
-
-        transform_ref.parent = self
-        self.children.append(transform_ref)
-
-    def create_child_ref(self, transform_path, child_id=None):
+    def set_parent(self, parent):
         """
-        Creates a new child TransformRef with transform_path specified.
-        :param transform_path:
-        :param child_id:
-        :return: TransformRef child
-        """
-        transform_ref = TransformRef(transform_path, child_id)
-        self.add_child_ref(transform_ref)
-        return transform_ref
+        Set the parent transform reference.
 
-    def get_rendered_transform_path(self):
+        :param parent: Parent transform reference.
+        :return: None.
         """
-        Generates a rendered transform path
-        that is calculated from all parents.
-        :return:
+        # Make sure the parent transform reference is valid.
+        if (parent is not None) and not isinstance(parent, TransformRef):
+            raise ValueError("parent must be None or of type TransformRef")
+
+        # Do nothing if the parent hasn't changed.
+        if self.parent is parent:
+            return
+
+        # Unset the old parent.
+        old_parent = self.parent
+        if old_parent is not None:
+            old_parent.remove_child(self)
+
+        # Set the new parent.
+        self.parent = parent
+        if parent is not None:
+            parent.add_child(self)
+
+    def add_child(self, child):
+        """
+        Adds the child transform reference if it doesn't exist. Also converts the child's transform path to
+        a parent-relative path.
+
+        :param child: Child transform reference.
+        :return: None.
+        """
+        # Make sure we have a valid transform reference.
+        if not isinstance(child, TransformRef):
+            raise ValueError("child must be of type TransformRef")
+
+        # Make sure we have a valid list.
+        if self.children is None:
+            self.children = []
+
+        # Add the child and update its transform path.
+        #
+        # Note that transform references with a parent use parent-relative transform paths.
+        if child not in self.children:
+            child.parent = self
+            child.transform_path = child.get_relative_transform_path()
+            self.children.append(child)
+
+    def remove_child(self, child):
+        """
+        Removes the child transform reference if it exists. Also converts the child's transform path to
+        an absolute path.
+
+        :param child: Child transform reference.
+        :return: None.
+        """
+        # Make sure we have a valid transform reference.
+        if not isinstance(child, TransformRef):
+            raise ValueError("child must be of type TransformRef")
+
+        # Bail if we don't have a valid list.
+        if self.children is None:
+            return
+
+        # Remove the child and update its transform path.
+        #
+        # Note that transform references without a parent use absolute transform paths.
+        if child in self.children:
+            child.transform_path = child.get_absolute_transform_path()
+            child.parent = None
+            self.children.remove(child)
+
+    def get_relative_transform_path(self):
+        """
+        Gets the parent-relative path of the transform reference.
+
+        :return: The parent-relative transform path, if the transform reference has a parent; otherwise, the absolute
+        transform path.
         """
         path = self.transform_path
-        parent = self.parent
 
+        if self.parent is not None:
+            path = path.split('/')[-1]
+
+        return path
+
+    def get_absolute_transform_path(self):
+        """
+        Gets the absolute path of the transform reference by traversing its parents.
+
+        :return: The absolute transform path.
+        """
+        path = self.transform_path
+
+        parent = self.parent
         while parent is not None:
             path = "{0}/{1}".format(parent.transform_path, path)
             parent = parent.parent
 
         return path
 
-    def get_rendered_transform_path_relative(self, relative_transform_ref):
+    def _get_sibling_indices(self, absolute_transform_path):
         """
-        Generates a rendered transform path relative to
-        parent.
-        :param relative_transform_ref:
-        :return:
-        """
-        path = self.transform_path
-        parent = self.parent
+        Constructs a list containing the sibling indices of this transform reference and all its ancestors, which is
+        used to distinguish between transforms with the same transform path.
 
-        while parent is not None and parent is not relative_transform_ref:
-            path = "{0}/{1}".format(parent.transform_path, path)
+        Ancestor sibling indices are listed before descendants.
+
+        The number of sibling indices will match the number of sections in the transform path of this transform
+        reference. For example, if the transform path is "PauseMenu/ReplayButton/Text", this method will return 3
+        sibling indices. If there aren't enough sibling indices available, the list will be left-padded with `None`.
+
+        If all sibling indices are -1, this method will return `None` instead of a list. This shorthand not only
+        decreases the size of request payloads containing transform references, but also allows Unity to find the
+        requested transform more efficiently by using the transform path directly.
+
+        :param absolute_transform_path: Absolute transform path of the specified transform reference. This is passed
+        in because it was already calculated earlier.
+
+        :return: A list containing the sibling indices of this transform reference and all its ancestors.
+        """
+        # Construct a list containing the sibling indices of this transform reference and all its ancestors.
+        indices = [self.sibling_index]
+        parent = self.parent
+        while parent is not None:
+            indices.insert(0, parent.sibling_index)
             parent = parent.parent
 
-        return path
+        # If all sibling indices are -1, just return None. This not only decreases the size of the request payload,
+        # but also allows Unity to find the requested transform more efficiently.
+        if indices.count(-1) == len(indices):
+            return None
+
+        # Make sure the number of sibling indices matches the number of elements in transform_path.
+        path_parts = absolute_transform_path.split('/')
+        while len(indices) < len(path_parts):
+            indices.insert(0, -1)
+
+        return indices
+
+    @staticmethod
+    def to_payload(transform_ref):
+        """
+        Converts a transform reference to a request payload to be sent to the server.
+
+        The resulting payload only contains the ``transform_path`` and ``sibling_indices`` attributes since that is
+        sufficient to unambiguously specify transforms when sending requests to the server.
+
+        :param transform_ref: The transform reference to convert.
+        :return: A request payload representing the transform reference that can be sent to the server.
+        """
+        # Bail if there's nothing to convert.
+        if transform_ref is None:
+            return None
+
+        # Make sure we have a valid transform reference to convert.
+        if not isinstance(transform_ref, TransformRef):
+            raise ValueError('transform_ref must be a type of TransformRef.')
+
+        # Convert the transform reference to a serializable payload.
+        #
+        # NOTE: Because the request payload doesn't include parent information, we need to specify the absolute
+        #       transform path so that Unity can find the requested transform.
+
+        transform_path = transform_ref.get_absolute_transform_path()
+        sibling_indices = transform_ref._get_sibling_indices(transform_path)
+
+        payload = {
+            "transform_path": transform_path,
+            "sibling_indices": sibling_indices,
+            "children": None,
+            "parent": None
+        }
+
+        return payload
+
+    @staticmethod
+    def from_payload(payload, parent=None):
+        """
+        Converts a response payload received from the server to a transform reference.
+
+        Response payloads don't include parent information, so an optional reference to a parent transform may be
+        specified to complete the initialization of the returned transform reference.
+
+        :param payload: The response payload to convert.
+        :param parent: Optional reference to a parent transform.
+        :return: A transform reference representing the payload that was received from the server.
+        """
+        # Bail if there's nothing to convert.
+        if payload is None:
+            return None
+
+        # Make sure the parent transform reference is valid.
+        if (parent is not None) and not isinstance(parent, TransformRef):
+            raise ValueError("parent must be None or of type TransformRef")
+
+        # Create the transform reference.
+        transform_ref = TransformRef(payload['transform_path'], payload['sibling_indices'][0], parent)
+
+        # Initialize the child transform references.
+        if payload['children'] is not None:
+            transform_ref.children = []
+            for child_payload in payload['children']:
+                TransformRef.from_payload(child_payload, transform_ref)
+
+        return transform_ref
+
+    @staticmethod
+    def list_to_payload(transform_refs):
+        """
+        Converts a list of transform references to a request payload to be sent to the server.
+
+        The resulting payload only contains the ``transform_path`` and ``sibling_indices`` attributes since that is
+        sufficient to unambiguously specify transforms when sending requests to the server.
+
+        :param transform_refs: The list of transform reference to convert.
+        :return: A request payload representing the transform references that can be sent to the server.
+        """
+        # Bail if there's nothing to convert.
+        if transform_refs is None:
+            return None
+
+        # Convert the transform references to a serializable payload.
+        payload = []
+
+        for transform_ref in transform_refs:
+            transform_ref_payload = TransformRef.to_payload(transform_ref)
+            payload.append(transform_ref_payload)
+
+        return payload
+
+    @staticmethod
+    def list_from_payload(payload, parent=None):
+        """
+        Converts a response payload received from the server to a list of transform references.
+
+        Response payloads don't include parent information, so an optional reference to a parent transform may be
+        specified to complete the initialization of the returned transform references.
+
+        :param payload: The response payload to convert.
+        :param parent: Optional reference to a parent transform.
+        :return: A list of transform references representing the payload that was received from the server.
+        """
+        # Bail if there's nothing to convert.
+        if payload is None:
+            return None
+
+        # Make sure the parent transform reference is valid.
+        if (parent is not None) and not isinstance(parent, TransformRef):
+            raise ValueError("parent must be None or of type TransformRef")
+
+        # Convert the payload to a list of transform references.
+        transform_refs = []
+
+        for transform_ref_payload in payload:
+            transform_ref = TransformRef.from_payload(transform_ref_payload, parent)
+            transform_refs.append(transform_ref)
+
+        return transform_refs

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,6 @@ setup(
     setup_requires=setup_requirements,
     tests_require=test_requirements,
     url='https://github.com/AgeOfLearning/coeus-unity-python-framework',
-    version='0.1.14',
+    version='0.1.15',
     zip_safe=False,
 )

--- a/tests/test_transform_ref.py
+++ b/tests/test_transform_ref.py
@@ -4,15 +4,14 @@ from coeus_unity.transform import TransformRef
 
 class TransformRefTestCase(unittest.TestCase):
     def test_calculate_path(self):
-        transform_a = TransformRef("Some/Path")
-        transform_b = TransformRef("Other")
-        transform_b.add_child_ref(transform_a)
+        menu = TransformRef("Path/To/Menu")
 
-        assert transform_a.get_rendered_transform_path() == "Other/Some/Path"
+        button = TransformRef("Button", parent=menu)
+        assert button.transform_path == "Button"
+        assert button.get_relative_transform_path() == "Button"
+        assert button.get_absolute_transform_path() == "Path/To/Menu/Button"
 
-    def test_calculate_path_relative(self):
-        transform_a = TransformRef("Some/Path")
-        transform_b = TransformRef("Other")
-        transform_b.add_child_ref(transform_a)
-
-        assert transform_a.get_rendered_transform_path_relative(transform_b) == "Some/Path"
+        button.set_parent(None)
+        assert button.transform_path == "Path/To/Menu/Button"
+        assert button.get_relative_transform_path() == "Path/To/Menu/Button"
+        assert button.get_absolute_transform_path() == "Path/To/Menu/Button"


### PR DESCRIPTION
This update adds support for transform references, which use sibling indices in addition to the transform path to resolve ambiguities when multiple transforms have the same path.